### PR TITLE
Correct 'GNU Library General Public License'

### DIFF
--- a/markdown/GPLv2-LICENSE.md
+++ b/markdown/GPLv2-LICENSE.md
@@ -17,7 +17,7 @@ guarantee your freedom to share and change free software--to make sure the
 software is free for all its users. This General Public License applies to most
 of the Free Software Foundation's software and to any other program whose
 authors commit to using it. (Some other Free Software Foundation software is
-covered by the GNU Library General Public License instead.) You can apply it to
+covered by the GNU Lesser General Public License instead.) You can apply it to
 your programs, too.
 
 When we speak of free software, we are referring to freedom, not price. Our


### PR DESCRIPTION
https://www.gnu.org/licenses/gpl-2.0.html shows that this phrase is actually
'GNU Lesser General Public License'.

--
I happened to want a markdown version of GPLv2, found your project, and diffed the content of GLPv2 from the above url at gnu.org and the markdown version within your project. Aside from markdown changed within your project, I found this difference between the GLPv2 files.